### PR TITLE
Remove forced single colon notation

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -116,7 +116,6 @@ module.exports = {
     ],
     "selector-list-comma-newline-after": "always",
     "selector-pseudo-element-case": "lower",
-    "selector-pseudo-element-colon-notation": "single",
     "selector-type-case": "lower",
     "shorthand-property-no-redundant-values": true,
     // Ideally we'd have single quotes in functions


### PR DESCRIPTION
This will allow us to begin using double colon notation, as agreed upon during our best practices meeting.

I can create a separate PR for setting `selector-pseudo-element-colon-notation` to `double` once we're ready to begin failing the build on single colon notation.